### PR TITLE
Fix endianness checks for Python 2

### DIFF
--- a/Modules/_sha3/backport.inc
+++ b/Modules/_sha3/backport.inc
@@ -19,6 +19,17 @@
 #define Hashsize_FromLong PyInt_FromLong
 #endif /* PY_MAJOR_VERSION >= 3 */
 
+/* Python 2 only defines WORDS_BIGENDIAN. */
+#if !defined(PY_BIG_ENDIAN) && !defined(PY_LITTLE_ENDIAN)
+#ifdef WORDS_BIGENDIAN
+#define PY_BIG_ENDIAN 1
+#define PY_LITTLE_ENDIAN 0
+#else
+#define PY_BIG_ENDIAN 0
+#define PY_LITTLE_ENDIAN 1
+#endif
+#endif
+
 #if (PY_MAJOR_VERSION < 3) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 5)
 static PyObject*
 _Py_strhex(const char* argbuf, const Py_ssize_t arglen)

--- a/Modules/_sha3/sha3module.c
+++ b/Modules/_sha3/sha3module.c
@@ -17,6 +17,7 @@
 
 #include "Python.h"
 #include "../hashlib.h"
+#include "backport.inc"
 
 /* **************************************************************************
  *                          SHA-3 (Keccak) and SHAKE
@@ -120,8 +121,6 @@
 #define SHA3_done Keccak_HashFinal
 #define SHA3_squeeze Keccak_HashSqueeze
 #define SHA3_copystate(dest, src) memcpy(&(dest), &(src), sizeof(SHA3_state))
-
-#include "backport.inc"
 
 /*[clinic input]
 module _sha3


### PR DESCRIPTION
Python 2 doesn't define PY_BIG_ENDIAN or PY_LITTLE_ENDIAN, while both 2 and 3 define WORDS_BIGENDIAN where appropriate.

The first change is required to fix a build failure on s390x, while the second isn't strictly necessary since it falls back to the Keccak implementation's internal detection.