### PR TITLE
Don't use private pystrhex.h from CPython

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ pysha3 1.0.3-dev
 
 - Fix typo in documentation (sha3_228 -> sha3_224)
 - Add manylinux1 builder
+- Don't use privat pystrhex.h
 
 pysha3 1.0.2
 ------------

--- a/Modules/_sha3/backport.inc
+++ b/Modules/_sha3/backport.inc
@@ -30,7 +30,6 @@
 #endif
 #endif
 
-#if (PY_MAJOR_VERSION < 3) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 5)
 static PyObject*
 _Py_strhex(const char* argbuf, const Py_ssize_t arglen)
 {
@@ -74,6 +73,4 @@ _Py_strhex(const char* argbuf, const Py_ssize_t arglen)
 
     return retval;
 }
-#else
-#include "pystrhex.h"
-#endif /* < 3.5 */
+

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ class TestCommand(Command):
 exts = []
 sha3_depends = ["setup.py", "Modules/hashlib.h", "Modules/pymemsets.h"]
 sha3_depends.extend(glob("Modules/_sha3/kcp/*"))
+sha3_depends.append("Modules/_sha3/backport.inc")
 exts.append(
     Extension(
         "_pysha3",


### PR DESCRIPTION
Fixes a problem with builds on PyPy

Closes: #15
Signed-off-by: Christian Heimes <christian@python.org>