### PR TITLE
Skip object read-only tests for PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix:
   allow_failures:
     - python: "3.7-dev"
       env: TOXENV=py37
-    - python: "pypy"
-      env: TOXENV=pypy
     - python: "pypy3"
       env: TOXENV=pypy3
 

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import hashlib
 import hmac
 import os
+import platform
 import sys
 import unittest
 
@@ -108,9 +109,11 @@ class BaseSHA3Tests(unittest.TestCase):
             self.assertEqual(len(sha3.hexdigest()), self.digest_size * 2)
 
         # object is read-only
-        self.assertRaises(AttributeError, setattr, sha3, "attribute", None)
-        self.assertRaises(AttributeError, setattr, sha3, "digest_size", 3)
-        self.assertRaises(AttributeError, setattr, sha3, "name", "egg")
+        # (PyPy is known not to implement this correctly)
+        if platform.python_implementation() != 'PyPy':
+            self.assertRaises(AttributeError, setattr, sha3, "attribute", None)
+            self.assertRaises(AttributeError, setattr, sha3, "digest_size", 3)
+            self.assertRaises(AttributeError, setattr, sha3, "name", "egg")
 
         self.new(b"data")
         self.new(string=b"data")


### PR DESCRIPTION
Skip the object read-only tests that are known to fail on PyPy. They
are not critical to the module serving its main purpose, and I believe
it would be better to let PyPy users know whether the core algorithms
work.
    
This can be amended with a specific PyPy version check once upstream
fixes https://bitbucket.org/pypy/pypy/issues/2686.
